### PR TITLE
ちきゅう → GENIEE SFA/CRM(旧ちきゅう)に伴うプロダクト名称、setup情報の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chikyu-sdk-python
 ## 概要
-ちきゅうのWeb APIをPythonから利用するためのライブラリです。
+GENIEE SFA/CRM(旧ちきゅう)のWeb APIをPythonから利用するためのライブラリです。
 
 SDKの開発にはPython2.7.11を利用しています。
 
@@ -79,8 +79,8 @@ from chikyu_sdk.config.api_config import ApiConfig
 from chikyu_sdk.resource.token import Token
 
 # ・トークン名称(任意)
-# ・ちきゅうのログイン用メールアドレス
-# ・ちきゅうのログイン用パスワード
+# ・GENIEE SFA/CRM(旧ちきゅう)のログイン用メールアドレス
+# ・GENIEE SFA/CRM(旧ちきゅう)のログイン用パスワード
 # ・トークンの有効期限(デフォルトでは24時間 - 秒で指定)
 token = Token.create('token_name', 'email', 'password', 86400)
 

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,15 @@ setup(
 
     version='0.9.0',
 
-    description='Chikyu SDK',
+    description='GENIEE SFA/CRM SDK',
 
     long_description=long_description,
 
     url='https://github.com/chikyuinc/chikyu-sdk-python',
 
-    author='Chikyu Inc.',
+    author='Geniee Inc.',
 
-    author_email='ishikawa_kousuke@chikyu.net',
+    author_email='',
 
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
背景:https://geniee.slack.com/archives/GB4M765EV/p1738027313299119?thread_ts=1738026852.120789&cid=GB4M765EV

