### PR TITLE
《B》次回 SFATB-642 ヘッダーでレスポンスにHTTPステータス要求するオプションと、has_errorがtrueの場合は400を検知できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ invoker = SecureResource(session)
 print(invoker.invoke('/entity/companies/list',  {'items_per_page': 10, 'page_index': 0}))
 ```
 
+## 設定オプション
+### HTTPステータスコードの使用
+デフォルトでは、APIエラー時もHTTPステータスコードは200が返されます。
+エラー時に適切なHTTPステータスコード（400等）を受け取りたい場合は、以下の設定を有効にしてください。
+
+```python
+from chikyu_sdk.config.api_config import ApiConfig
+
+# HTTPステータスコードの使用を有効化
+ApiConfig.set_use_http_status(True)
+```
+
+この設定を有効にすると、`has_error`がtrueのレスポンスでHTTP 400が返されます。例外の`http_status`プロパティでステータスコードを取得できます。
+
+```python
+from chikyu_sdk.error.common_errors import ApiExecuteException
+
+try:
+    result = invoker.invoke('/entity/companies/create', {})
+except ApiExecuteException as e:
+    print(e.http_status)  # 400
+    print(str(e))         # エラーメッセージ
+```
+
 ## 詳細
 ### class1(APIキーのみで呼び出し可能)
 #### APIキーを生成する

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='chikyu-sdk',
 
-    version='0.9.0',
+    version='0.10.0',
 
     description='GENIEE SFA/CRM SDK',
 

--- a/src/chikyu_sdk/api_resource.py
+++ b/src/chikyu_sdk/api_resource.py
@@ -32,7 +32,15 @@ class ApiResource(object):
 
     @classmethod
     def _handle_response(cls, path, resp):
-        if resp.status_code != 200:
+        use_http_status = ApiConfig.use_http_status()
+        http_status = resp.status_code
+
+        if use_http_status:
+            allowed_status_codes = [200, 400]
+        else:
+            allowed_status_codes = [200]
+
+        if http_status not in allowed_status_codes:
             try:
                 item = resp.json()
                 if 'message' in item:
@@ -44,12 +52,12 @@ class ApiResource(object):
 
             if six.PY2:
                 msg = u"httpエラーが発生しました -> url={} / status={} / message={}".format(
-                    to_str(path), to_str(resp.status_code), to_str(err_msg))
+                    to_str(path), to_str(http_status), to_str(err_msg))
             else:
                 msg = \
-                    u"httpエラーが発生しました -> url={} / status={} / message={}".format(path, resp.status_code, err_msg)
+                    u"httpエラーが発生しました -> url={} / status={} / message={}".format(path, http_status, err_msg)
             cls._logger.error(msg)
-            raise HttpException(msg)
+            raise HttpException(msg, http_status=http_status)
 
         content = resp.json()
         if content['has_error']:
@@ -62,7 +70,7 @@ class ApiResource(object):
             else:
                 msg = "APIの実行に失敗しました"
             cls._logger.error(msg)
-            raise ApiExecuteException(msg)
+            raise ApiExecuteException(msg, http_status=http_status)
 
         if 'data' in content:
             return to_unicode_all(content['data'])

--- a/src/chikyu_sdk/config/api_config.py
+++ b/src/chikyu_sdk/config/api_config.py
@@ -3,6 +3,7 @@
 
 class ApiConfig(object):
     __mode = 'prod'
+    __use_http_status = False
 
     __HOSTS = {
         'local': 'localhost:9090',
@@ -73,3 +74,19 @@ class ApiConfig(object):
     def set_mode(cls, mode):
         cls.__mode = mode
 
+    @classmethod
+    def use_http_status(cls):
+        """HTTPステータスコードを使用するかどうかを取得する。
+
+        :rtype: bool
+        :return: HTTPステータスコードを使用する場合はTrue
+        """
+        return cls.__use_http_status
+
+    @classmethod
+    def set_use_http_status(cls, value):
+        """HTTPステータスコードを使用するかどうかを設定する。
+
+        :param value: HTTPステータスコードを使用する場合はTrue
+        """
+        cls.__use_http_status = value

--- a/src/chikyu_sdk/error/common_errors.py
+++ b/src/chikyu_sdk/error/common_errors.py
@@ -2,8 +2,22 @@
 
 
 class HttpException(Exception):
-    pass
+    """HTTP通信エラーを表す例外クラス。
+
+    :param message: エラーメッセージ
+    :param http_status: HTTPステータスコード
+    """
+    def __init__(self, message, http_status=None):
+        super(HttpException, self).__init__(message)
+        self.http_status = http_status
 
 
 class ApiExecuteException(Exception):
-    pass
+    """API実行エラーを表す例外クラス。
+
+    :param message: エラーメッセージ
+    :param http_status: HTTPステータスコード
+    """
+    def __init__(self, message, http_status=None):
+        super(ApiExecuteException, self).__init__(message)
+        self.http_status = http_status

--- a/src/chikyu_sdk/open_resource.py
+++ b/src/chikyu_sdk/open_resource.py
@@ -3,6 +3,7 @@
 import requests
 
 from chikyu_sdk.api_resource import ApiResource
+from chikyu_sdk.config.api_config import ApiConfig
 
 
 class OpenResource(ApiResource):
@@ -16,10 +17,14 @@ class OpenResource(ApiResource):
         """
         params = {'data': data}
 
+        headers = {'content-type': 'application/json'}
+        if ApiConfig.use_http_status():
+            headers['Error-Response'] = 'http-status'
+
         url = cls._build_url("open", path)
         resp = requests.post(
             url,
             json=params,
-            headers={'content-type': 'application/json'})
+            headers=headers)
 
         return cls._handle_response(path, resp)

--- a/src/chikyu_sdk/public_resource.py
+++ b/src/chikyu_sdk/public_resource.py
@@ -3,6 +3,7 @@
 import requests
 
 from chikyu_sdk.api_resource import ApiResource
+from chikyu_sdk.config.api_config import ApiConfig
 
 
 class PublicResource(ApiResource):
@@ -24,12 +25,14 @@ class PublicResource(ApiResource):
         """
         params = {'data': data}
 
+        headers = {'content-type': 'application/json', 'x-api-key': self.__api_key, 'x-auth-key': self.__auth_key}
+        if ApiConfig.use_http_status():
+            headers['Error-Response'] = 'http-status'
+
         url = self._build_url("public", path)
         resp = requests.post(
             url,
             json=params,
-            headers={'content-type': 'application/json',
-                     'x-api-key': self.__api_key,
-                     'x-auth-key': self.__auth_key})
+            headers=headers)
 
         return self._handle_response(path, resp)

--- a/src/chikyu_sdk/secure_resource.py
+++ b/src/chikyu_sdk/secure_resource.py
@@ -34,10 +34,14 @@ class SecureResource(ApiResource):
         if ApiConfig.mode() == "local" or ApiConfig.mode() == "docker":
             params['identity_id'] = self.__session.identity_id
 
+        headers = {'x-api-key': self.__session.api_key, 'content-type': 'application/json'}
+        if ApiConfig.use_http_status():
+            headers['Error-Response'] = 'http-status'
+
         res = requests.post(
             url=url,
             json=params,
-            headers={'x-api-key': self.__session.api_key, 'content-type': 'application/json'},
+            headers=headers,
             auth=self.__auth
         )
 


### PR DESCRIPTION
## JIRA

https://geniee.atlassian.net/browse/SFATB-642




  ## E2Eテスト結果                                                                                                                                                             
                                                                                                                                                                               
  ### テスト目的                                                                                                                                                               
                                                                                                                                                                               
  本テストは、PR #11 で追加した `use_http_status` オプション機能の動作検証を目的としたE2Eテスト（実際のAPI呼び出しによる結合テスト）です。                                     
                                                                                                                                                                               
  ### テスト観点                                                                                                                                                               
                                                                                                                                                                               
  以下の観点で網羅的にテストを実施し、本機能がエビデンスとして十分であることを確認しました。                                                                                   
                                                                                                                                                                               
  | 観点 | 説明 | 網羅性の根拠 |                                                                                                                                               
  |------|------|-------------|                                                                                                                                                
  | **新機能の動作確認** | `use_http_status=True` 時にエラーレスポンスでHTTP 400が返ること | 全APIレベル（Open/Public/Secure）で検証 |                                         
  | **後方互換性（デグレ確認）** | `use_http_status=False`（デフォルト）時に従来通りHTTP 200が返ること | 全APIレベルで検証 |                                                   
  | **正常系への影響なし** | HTTPステータスモード有効時も、正常レスポンスは200のままであること | Public/Secure APIで検証 |                                                     
  | **例外オブジェクトの検証** | `ApiExecuteException.http_status` でステータスコードが取得できること | 全エラーケースで検証 |                                                 
                                                                                                                                                                               
  ### テストケース一覧                                                                                                                                                         
                                                                                                                                                                               
  | No | APIレベル | テストケース | モード | 期待HTTP | 実際HTTP | 結果 |                                                                                                      
  |----|-----------|-------------|--------|----------|----------|------|                                                                                                       
  | 1 | Open | token/create (無効パラメータ) | 通常 | 200 | 200 | ✅ |                                                                                                         
  | 2 | Open | token/create (無効パラメータ) | HTTPステータス | 400 | 400 | ✅ |                                                                                               
  | 3 | Public | companies/list | 通常 | 200 | 200 | ✅ |                                                                                                                      
  | 4 | Public | companies/create (fieldsなし) | 通常 | 200 | 200 | ✅ |                                                                                                       
  | 5 | Public | companies/list | HTTPステータス | 200 | 200 | ✅ |                                                                                                            
  | 6 | Public | companies/create (fieldsなし) | HTTPステータス | 400 | 400 | ✅ |                                                                                             
  | 7 | Secure | companies/list | 通常 | 200 | 200 | ✅ |                                                                                                                      
  | 8 | Secure | companies/create (fieldsなし) | 通常 | 200 | 200 | ✅ |                                                                                                       
  | 9 | Secure | companies/list | HTTPステータス | 200 | 200 | ✅ |                                                                                                            
  | 10 | Secure | companies/create (fieldsなし) | HTTPステータス | 400 | 400 | ✅ |                                                                                            
  | 11 | Secure | unknown/unknown (存在しないAPI) | HTTPステータス | 400 | 400 | ✅ |                                                                                          
                                                                                                                                                                               
  ### テスト結果: 11/11 passed ✅                                                                                                                                              
                                                                                                                                                                               
  ### エビデンスとして十分である根拠                                                                                                                                           
                                                                                                                                                                               
  1. **全APIレベルの網羅**: Open API / Public API / Secure API の3種類全てで動作確認                                                                                           
  2. **正常系・異常系の両方を検証**: 各APIレベルで成功ケースと失敗ケースを実施                                                                                                 
  3. **モード切替の動作確認**: 同一エラー条件で `use_http_status=True/False` 両方のモードを比較検証                                                                            
  4. **実際のAPI呼び出し**: モックではなく、dev05環境への実API呼び出しによるE2Eテスト                                                                                          
  5. **後方互換性の担保**: デフォルト（False）では従来動作を維持することを確認                                                                                                 
                                                                                                                                                                               
  ### 実行環境                                                                                                                                                                 
                                                                                                                                                                               
  | 項目 | 値 |                                                                                                                                                                
  |------|-----|                                                                                                                                                               
  | 実行日時 | 2026-02-02 17:24:23 |                                                                                                                                           
  | API環境 | dev05 (gateway.chikyu.mobi) |                                                                                                                                                                                                                                           
                                                                                                                                                                               
  <details>                                                                                                                                                                    
  <summary>実行ログ（クリックで展開）</summary>                                                                                                                                
                                                                                                                                                                               
  2026-02-02 17:24:23 | INFO     | E2E TEST SETUP                                                                                                                              
  2026-02-02 17:24:23 | INFO     |   API Mode: dev05                                                                                                                           
  2026-02-02 17:24:23 | INFO     |   Host: gateway.chikyu.mobi                                                                                                                 
  2026-02-02 17:24:27 | INFO     |   Token created!                                                                                                                            
  2026-02-02 17:24:31 | INFO     |   Login successful!                                                                                                                         
  2026-02-02 17:24:36 | INFO     |   API Key created!                                                                                                                          
                                                                                                                                                                               
  2026-02-02 17:24:37 | INFO     | TEST: Open API - Normal Mode - Error (Invalid Params)                                                                                       
  2026-02-02 17:24:37 | INFO     |   Mode: 通常モード (use_http_status=False)                                                                                                  
  2026-02-02 17:24:37 | INFO     |   Result: PASS ✓ (expected: 200, actual: 200)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:37 | INFO     | TEST: Open API - HTTP Status Mode - Error (Invalid Params)                                                                                  
  2026-02-02 17:24:37 | INFO     |   Mode: HTTPステータスモード (use_http_status=True)                                                                                         
  2026-02-02 17:24:37 | INFO     |   Result: PASS ✓ (expected: 400, actual: 400)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:45 | INFO     | TEST: Public API - Normal Mode - Success (List)                                                                                             
  2026-02-02 17:24:45 | INFO     |   Result: PASS ✓                                                                                                                            
                                                                                                                                                                               
  2026-02-02 17:24:47 | INFO     | TEST: Public API - Normal Mode - Error (No Fields)                                                                                          
  2026-02-02 17:24:47 | INFO     |   Result: PASS ✓ (expected: 200, actual: 200)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:48 | INFO     | TEST: Public API - HTTP Status Mode - Success (List)                                                                                        
  2026-02-02 17:24:48 | INFO     |   Result: PASS ✓                                                                                                                            
                                                                                                                                                                               
  2026-02-02 17:24:48 | INFO     | TEST: Public API - HTTP Status Mode - Error (No Fields)                                                                                     
  2026-02-02 17:24:48 | INFO     |   Result: PASS ✓ (expected: 400, actual: 400)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:49 | INFO     | TEST: Secure API - Normal Mode - Success (List)                                                                                             
  2026-02-02 17:24:49 | INFO     |   Result: PASS ✓                                                                                                                            
                                                                                                                                                                               
  2026-02-02 17:24:55 | INFO     | TEST: Secure API - Normal Mode - Error (No Fields)                                                                                          
  2026-02-02 17:24:55 | INFO     |   Result: PASS ✓ (expected: 200, actual: 200)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:55 | INFO     | TEST: Secure API - HTTP Status Mode - Success (List)                                                                                        
  2026-02-02 17:24:55 | INFO     |   Result: PASS ✓                                                                                                                            
                                                                                                                                                                               
  2026-02-02 17:24:56 | INFO     | TEST: Secure API - HTTP Status Mode - Error (No Fields)                                                                                     
  2026-02-02 17:24:56 | INFO     |   Result: PASS ✓ (expected: 400, actual: 400)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:56 | INFO     | TEST: Secure API - Unknown API (400 Expected)                                                                                               
  2026-02-02 17:24:56 | INFO     |   Result: PASS ✓ (expected: 400, actual: 400)                                                                                               
                                                                                                                                                                               
  2026-02-02 17:24:57 | INFO     | TEST SUMMARY: 11/11 passed                                                                                                                  
                                                                                                                                                                               
  </details>  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * APIエラー時にHTTPステータスを有効化する設定オプションを追加しました（切替可能）。
  * 設定に応じてエラーレスポンスのHTTPステータスを返す/返さないを制御します。
  * リクエストに条件付きでエラー用ヘッダーを付与するようになりました（Open/Public/Secure共通）。

* **改善**
  * 発生したAPIエラーでHTTPステータスが参照できるよう例外情報を強化しました。

* **ドキュメント**
  * 設定オプションの利用方法をREADMEに追記しました。

* **雑務**
  * パッケージ版番を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->